### PR TITLE
Use random temp directory for progress estimator (fix concurrent builds)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^18.0.0",
@@ -25,6 +25,7 @@
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.23.1",
         "eslint-plugin-react-hooks": "^4.2.0",
+        "find-cache-dir": "^3.3.1",
         "fs-extra": "^9.1.0",
         "jest": "^26.6.3",
         "jest-watch-typeahead": "^0.6.2",
@@ -43,6 +44,7 @@
         "rollpkg": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/find-cache-dir": "^3.2.0",
         "@types/fs-extra": "^9.0.10",
         "@types/mock-fs": "^4.13.0",
         "@types/node": "^14.14.37",
@@ -1184,6 +1186,12 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+    },
+    "node_modules/@types/find-cache-dir": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+      "integrity": "sha512-+JeT9qb2Jwzw72WdjU+TSvD5O1QRPWCeRpDJV+guiIq+2hwR0DFGw+nZNbTFjMIVe6Bf4GgAKeB/6Ytx6+MbeQ==",
+      "dev": true
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.10",
@@ -20369,6 +20377,12 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+    },
+    "@types/find-cache-dir": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+      "integrity": "sha512-+JeT9qb2Jwzw72WdjU+TSvD5O1QRPWCeRpDJV+guiIq+2hwR0DFGw+nZNbTFjMIVe6Bf4GgAKeB/6Ytx6+MbeQ==",
+      "dev": true
     },
     "@types/fs-extra": {
       "version": "9.0.10",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "find-cache-dir": "^3.3.1",
     "fs-extra": "^9.1.0",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.2",
@@ -70,6 +71,7 @@
     "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {
+    "@types/find-cache-dir": "^3.2.0",
     "@types/fs-extra": "^9.0.10",
     "@types/mock-fs": "^4.13.0",
     "@types/node": "^14.14.37",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import {
   createBundles,
   writeBundles,
 } from './rollupBuilds';
-import { progressEstimator, cleanDist } from './utils';
+import { progressEstimatorBuilder, cleanDist } from './utils';
 import {
   EXIT_ON_ERROR,
   errorAsObjectWithMessage,
@@ -24,6 +24,8 @@ const rollpkg = async () => {
   /////////////////////////////////////
   // clean dist folder
   const cleanDistMessage = 'Cleaning dist folder';
+  const progressEstimator = await progressEstimatorBuilder();
+
   try {
     const clean = cleanDist();
     await progressEstimator(clean, cleanDistMessage);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import {
   createBundles,
   writeBundles,
 } from './rollupBuilds';
-import { progressEstimatorBuilder, cleanDist } from './utils';
+import { progressEstimator, cleanDist } from './utils';
 import {
   EXIT_ON_ERROR,
   errorAsObjectWithMessage,
@@ -24,8 +24,6 @@ const rollpkg = async () => {
   /////////////////////////////////////
   // clean dist folder
   const cleanDistMessage = 'Cleaning dist folder';
-  const progressEstimator = await progressEstimatorBuilder();
-
   try {
     const clean = cleanDist();
     await progressEstimator(clean, cleanDistMessage);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,18 @@
+import * as os from 'os';
 import * as fs from 'fs-extra';
 import { resolve } from 'path';
 import * as readline from 'readline';
+import findCacheDir from 'find-cache-dir';
 import createProgressEstimator from 'progress-estimator';
 
+export const getCacheDir = (...pathParts: string[]): string => {
+  const thunk = findCacheDir({ name: 'rollpkg', create: true, thunk: true });
+
+  return thunk ? thunk(...pathParts) : resolve(os.tmpdir(), ...pathParts);
+}
+
 export const progressEstimator = createProgressEstimator({
-  storagePath: resolve(__dirname, '.progress-estimator'),
+  storagePath: getCacheDir('progress-estimator'),
   spinner: {
     interval: 180,
     frames: ['🌎', '🌏', '🌍'],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,23 +1,15 @@
 import * as fs from 'fs-extra';
-import { resolve, join } from 'path';
-import * as os from 'os';
+import { resolve } from 'path';
 import * as readline from 'readline';
-import createProgressEstimator, { ProgressEstimator } from 'progress-estimator';
+import createProgressEstimator from 'progress-estimator';
 
-export const createRandomProgressEstimatorTempDir: () => Promise<string> = () =>
-  fs.mkdtemp(join(os.tmpdir(), 'progress-estimator-'));
-
-export const progressEstimatorBuilder: () => Promise<ProgressEstimator> = async () => {
-  const tempDirPath = await createRandomProgressEstimatorTempDir();
-
-  return createProgressEstimator({
-    storagePath: tempDirPath,
-    spinner: {
-      interval: 180,
-      frames: ['🌎', '🌏', '🌍'],
-    },
-  });
-};
+export const progressEstimator = createProgressEstimator({
+  storagePath: resolve(__dirname, '.progress-estimator'),
+  spinner: {
+    interval: 180,
+    frames: ['🌎', '🌏', '🌍'],
+  },
+});
 
 export const cleanDist: () => Promise<void> = () => fs.emptyDir('./dist');
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,23 @@
 import * as fs from 'fs-extra';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
+import * as os from 'os';
 import * as readline from 'readline';
-import createProgressEstimator from 'progress-estimator';
+import createProgressEstimator, { ProgressEstimator } from 'progress-estimator';
 
-export const progressEstimator = createProgressEstimator({
-  storagePath: resolve(__dirname, '.progress-estimator'),
-  spinner: {
-    interval: 180,
-    frames: ['🌎', '🌏', '🌍'],
-  },
-});
+export const createRandomProgressEstimatorTempDir: () => Promise<string> = () =>
+  fs.mkdtemp(join(os.tmpdir(), 'progress-estimator-'));
+
+export const progressEstimatorBuilder: () => Promise<ProgressEstimator> = async () => {
+  const tempDirPath = await createRandomProgressEstimatorTempDir();
+
+  return createProgressEstimator({
+    storagePath: tempDirPath,
+    spinner: {
+      interval: 180,
+      frames: ['🌎', '🌏', '🌍'],
+    },
+  });
+};
 
 export const cleanDist: () => Promise<void> = () => fs.emptyDir('./dist');
 


### PR DESCRIPTION
I have been using `rollpkg` to build packages in monorepo by `lerna` (https://github.com/lerna/lerna). I have one instance of `rollpkg` in root monorepo directory. `lerna` builds 5-6 packages concurrently and sometimes one of builds ends with `progress-estimator` error. It uses the same cache folder for every build process, and sometimes it creates file conflict.

I created this update to resolve this issue by using system tmp directory with random sub-directory for every new `rollpkg` build. I've been testing this for a month in my local monorepo and proposed solution works without any problems.

![image](https://user-images.githubusercontent.com/749112/117972235-27f0f300-b32b-11eb-84fd-1752f516f8f8.png)
